### PR TITLE
Enable unit tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,5 +15,15 @@ jobs:
           cache: "pnpm"
       - run: |
           pnpm install
+      - run: |
           # issue-266: enable "memory" related packages when they are ready
           pnpm --filter='!./packages/memory*' -r build
+      - name: Run tests
+        run: |
+          pnpm \
+            --filter '!./packages/api-fetch-client' \
+            --filter '!./packages/blobs' \
+            --filter '!./packages/converters' \
+            --filter '!./packages/common' \
+            --filter '!./packages/workflow' \
+            -r test


### PR DESCRIPTION
This PR enables the unit tests in composableai. Some packages are excluded on purpose because their tests are failing, we can fix them later on. This PR is related to

* https://github.com/becomposable/studio/issues/159