### PR TITLE
bug(421) Set mime-type when uploading an object

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
         "json-schema": "^0.4.0",
         "json-schema-to-typescript": "^13.1.1",
         "jsonwebtoken": "^9.0.2",
+        "mime": "^4.0.4",
         "node-web-stream-adapters": "^0.1.0",
         "open": "^10.1.0",
         "seedrandom": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      mime:
+        specifier: ^4.0.4
+        version: 4.0.4
       node-web-stream-adapters:
         specifier: ^0.1.0
         version: 0.1.0
@@ -2517,6 +2520,11 @@ packages:
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  mime@4.0.4:
+    resolution: {integrity: sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==}
+    engines: {node: '>=16'}
     hasBin: true
 
   mimic-fn@4.0.0:
@@ -5554,6 +5562,8 @@ snapshots:
       mime-db: 1.52.0
 
   mime@3.0.0: {}
+
+  mime@4.0.4: {}
 
   mimic-fn@4.0.0: {}
 


### PR DESCRIPTION
Issue:

- https://github.com/becomposable/studio/issues/421

Information:

- Files were uploaded with mime_type `application/octet-stream`
- `application/octet-stream` objects where not triggering `sys:SelectDocumentType` because they `don't have any text`
- Resolving mime_type before uploading the file fix the issue (mimic uploading a file using dropzone in content object view because the type is also resolved there)