### PR TITLE
Only clear stream if it is possible

### DIFF
--- a/packages/cli/src/utils/console.ts
+++ b/packages/cli/src/utils/console.ts
@@ -125,7 +125,7 @@ export class LogUpdate {
     }
 
     clear() {
-        if (this.last) {
+        if (this.last && this.stream.isTTY) {
             this.stream.clearLine(0);
             this.stream.cursorTo(0);
         }


### PR DESCRIPTION
Only clear the stream if the command line is connected to a terminal (isTTY=true), otherwise, don't try to clear it because the function will raise an error as this action is not available:

```
file:///home/runner/work/studio/studio/out/composableai/packages/cli/lib/utils/console.js:152
            this.stream.clearLine(0);
                        ^
TypeError: this.stream.clearLine is not a function
```