### PR TITLE
Increase startToCloseTimeout for interactive generation

### DIFF
--- a/packages/workflow/src/iterative-generation/iterativeGenerationWorkflow.ts
+++ b/packages/workflow/src/iterative-generation/iterativeGenerationWorkflow.ts
@@ -8,7 +8,7 @@ const {
     generateToc,
     generatePart
 } = proxyActivities<typeof activities>({
-    startToCloseTimeout: "5 minute",
+    startToCloseTimeout: "10 minute",
     retry: {
         initialInterval: '30s',
         backoffCoefficient: 2,


### PR DESCRIPTION
Currently LLMs are failing on the generation of the table of content (ToC) because the generation is complex. Let's increase the timeout on the Temporal side to give it more time for the execution.