### PR TITLE
Fix: remove memory-test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,22 +68,6 @@ jobs:
       - run: pnpm install
       - run: npm --prefix packages/json test
 
-  memory-test:
-    runs-on: ubuntu-latest
-    needs: composableai-build
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "pnpm"
-      - run: pnpm install
-      - run: pnpm build
-      - run: npm --prefix packages/memory test
-
   workflow-test:
     runs-on: ubuntu-latest
     needs: composableai-build


### PR DESCRIPTION
Since https://github.com/becomposable/composableai/commit/78019c84ab1c9e28eaf76e97f395a7e9d2d3d7f0 memory-related source code have been moved to another repository called [becomposable/memory](https://github.com/becomposable/memory). So setting up unit tests for this package is not relevant anymore. 