### PR TITLE
feat(498): expose optional param "run_data" for Interaction Execution API

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -86,6 +86,7 @@ program.command("run <interaction>")
     .option('-v, --verbose', 'Only used in no streaming mode. Instead of printing a progress it will print details about each executed run.')
     .option('--jsonl', 'Write output in jsonl. The default is to write the json. Ignored when only one run is executed')
     .option('--data-only', 'Write down only the data returned by the LLM and not the entire execution run. This mode is forced when streaming', false)
+    .option('-r, --run-data [level]', 'The level of storage for the run data. Possible values are: "standard", "restricted", or "debug". Optional.')
     .action((interaction: string, options: Record<string, any>) => runInteraction(program, interaction, options));
 program.command("runs [interactionId]")
     .description('Search the run history for specific execution runs')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -86,7 +86,7 @@ program.command("run <interaction>")
     .option('-v, --verbose', 'Only used in no streaming mode. Instead of printing a progress it will print details about each executed run.')
     .option('--jsonl', 'Write output in jsonl. The default is to write the json. Ignored when only one run is executed')
     .option('--data-only', 'Write down only the data returned by the LLM and not the entire execution run. This mode is forced when streaming', false)
-    .option('-r, --run-data [level]', 'The level of storage for the run data. Possible values are: "standard", "restricted", or "debug". Optional.')
+    .option('-r, --run-data [level]', 'Override the level of storage for the run data. Possible values are: "standard", "restricted", or "debug". Optional. If not specified, it uses the level defined in Studio.')
     .action((interaction: string, options: Record<string, any>) => runInteraction(program, interaction, options));
 program.command("runs [interactionId]")
     .description('Search the run history for specific execution runs')

--- a/packages/cli/src/run/executor.ts
+++ b/packages/cli/src/run/executor.ts
@@ -1,5 +1,5 @@
 import { ComposableClient } from "@becomposable/client";
-import { ExecutionRun } from "@becomposable/common";
+import { ExecutionRun, RunDataStorageLevel } from "@becomposable/common";
 
 export class ExecutionQueue {
     requests: ExecutionRequest[] = [];
@@ -26,6 +26,10 @@ export class ExecutionQueue {
 
 }
 
+function convertRunData(raw_run_data: any): RunDataStorageLevel | undefined {
+    const levelStr: string =  typeof raw_run_data === 'string' ? raw_run_data.toUpperCase() : "";
+    return Object.values(RunDataStorageLevel).includes(levelStr as RunDataStorageLevel) ? levelStr as RunDataStorageLevel : undefined;
+}
 
 export class ExecutionRequest {
 
@@ -41,13 +45,14 @@ export class ExecutionRequest {
     async run(onChunk?: ((chunk: any) => void)): Promise<ExecutionRun> {
         const options = this.options;
 
+
         const run = await this.client.interactions.executeByName(this.interactionSpec, {
             data: this.data,
             config: {
                 environment: typeof options.env === 'string' ? options.env : undefined,
                 model: typeof options.model === 'string' ? options.model : undefined,
                 temperature: typeof options.temperature === 'string' ? parseFloat(options.temperature) : undefined,
-                run_data: typeof options.run_data === 'string' ? JSON.parse(options.run_data) : undefined,
+                run_data: convertRunData(options.run_data),
             },
             tags: options.tags ? options.tags.trim().split(/\s,*\s*/) : undefined
         }, onChunk);

--- a/packages/cli/src/run/executor.ts
+++ b/packages/cli/src/run/executor.ts
@@ -47,6 +47,7 @@ export class ExecutionRequest {
                 environment: typeof options.env === 'string' ? options.env : undefined,
                 model: typeof options.model === 'string' ? options.model : undefined,
                 temperature: typeof options.temperature === 'string' ? parseFloat(options.temperature) : undefined,
+                run_data: typeof options.run_data === 'string' ? JSON.parse(options.run_data) : undefined,
             },
             tags: options.tags ? options.tags.trim().split(/\s,*\s*/) : undefined
         }, onChunk);

--- a/packages/cli/src/run/executor.ts
+++ b/packages/cli/src/run/executor.ts
@@ -52,7 +52,7 @@ export class ExecutionRequest {
                 environment: typeof options.env === 'string' ? options.env : undefined,
                 model: typeof options.model === 'string' ? options.model : undefined,
                 temperature: typeof options.temperature === 'string' ? parseFloat(options.temperature) : undefined,
-                run_data: convertRunData(options.run_data),
+                run_data: convertRunData(options.runData),
             },
             tags: options.tags ? options.tags.trim().split(/\s,*\s*/) : undefined
         }, onChunk);

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -252,6 +252,7 @@ export interface InteractionExecutionConfiguration {
     temperature?: number;
     max_tokens?: number;
     do_validate?: boolean;
+    run_data?: RunDataStorageLevel;
 }
 
 export interface GenerateInteractionPayload {

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -61,15 +61,6 @@ export enum ExecutionRunStatus {
     failed = "failed",
 }
 
-/**
- * @deprecated Use RunDataStorageLevel instead (since 0.39.1)
- */
-export enum RestrictionLevel {
-    STANDARD = "STANDARD",
-    RESTRICTED = "RESTRICTED",
-    DEBUG = "DEBUG"
-};
-
 export enum RunDataStorageLevel {
     STANDARD = "STANDARD",
     RESTRICTED = "RESTRICTED",


### PR DESCRIPTION
## Description

https://github.com/becomposable/studio/issues/498

For the Interaction Execution API, it will have a new, optional parameter "run_data" which allows user to control the level of storage for the data related to a run of an interaction: "standard", "restricted", or "debug". If parameter overrides the value defined in Studio, which provides more flexibility to executions.

## Testing

* Create an interaction with Run Data configured as STANDARD.
* Build the `composable` command line 
* Run the interaction locally with different levels: undefined, DEBUG, STANDARD, RESTRICTED, NON_EXISTENT; and with different cases. Ensure that the run data are stored correctly.


```sh
pnpm -r build
# ...
# packages/cli build$ rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build
# └─ Done in 830ms

cd packages/cli
```

See the new option "-r", "--run-data" in the help message of the command line:

```
node lib/index.js run -h
Usage: index run [options] <interaction>

Run an interaction by full name. The full name is composed by an optional namespace, a required endpoint name and
an optional tag or version. Examples: name, namespace:name, namespace:name@version

Options:
  -i, --input [file]               The input data if any. If no file path is specified it will read from stdin
  -o, --output [file]              The output file if any. If not specified it will print to stdout
  -d, --data [json]                Inline data as a JSON string. If specified takes precendence over --input
  -T, --tags [tags]                A comma separated list of tags to add to the execution run
  -t, --temperature [temperature]  The temperature to use
  -m, --model [model]              The model to use. Optional.
  -e, --env [environmentId]        The environment Id to use. Optional.
  -S, --no-stream                  When used, the output will be printed only when the execution is complete
  -c, --count [count]              The number of times to run the interaction (default: "1")
  -v, --verbose                    Only used in no streaming mode. Instead of printing a progress it will print
                                   details about each executed run.
  --jsonl                          Write output in jsonl. The default is to write the json. Ignored when only one
                                   run is executed
  --data-only                      Write down only the data returned by the LLM and not the entire execution run.
                                   This mode is forced when streaming (default: false)
  -r, --run-data [level]           Override the level of storage for the run data. Possible values are:
                                   "standard", "restricted", or "debug". Optional. If not specified, it uses the
                                   level defined in Studio.
  -h, --help                       display help for command
```

Connect to the dev environment

```sh
node lib/index.js profiles
# local-experiments
# production-experiments
# staging-experiments
# dev-mincong-fix-run-data-experiments ✔
```

Then, let `composable` to translate the following sentence using the TranslateContent interaction:

> _"L’automne est sourd, l’automne est aveugle. Il emporte, comme le vent emporte les feuilles, les rêves et les regrets."_ — Victor Hugo

Note that the Run Data level is set to "STANDARD" in the interaction.

### Restricted

Command

```sh
node lib/index.js run TranslateContent \
    --data '{"language": "en", "content": "L’automne est sourd, l’automne est aveugle. Il emporte, comme le vent emporte les feuilles, les rêves et les regrets."}' \
    --env xxx1e24 \
    --model gpt-3.5-turbo-16k \
    --run-data restricted \
    --temperature 0.5
```

Result:

![image](https://github.com/user-attachments/assets/423306e8-464e-4bf7-a89f-6ced29c82cf1)

### Standard

Command

```sh
node lib/index.js run TranslateContent \
    --data '{"language": "en", "content": "L’automne est sourd, l’automne est aveugle. Il emporte, comme le vent emporte les feuilles, les rêves et les regrets."}' \
    --env xxx1e24 \
    --model gpt-3.5-turbo-16k \
    --run-data standard \
    --temperature 0.5
```

Result:

![image](https://github.com/user-attachments/assets/b51eb03a-feb2-4168-b827-a3029c235290)

### Debug

Command

```sh
node lib/index.js run TranslateContent \
    --data '{"language": "en", "content": "L’automne est sourd, l’automne est aveugle. Il emporte, comme le vent emporte les feuilles, les rêves et les regrets."}' \
    --env xxx1e24 \
    --model gpt-3.5-turbo-16k \
    --run-data debug \
    --temperature 0.5
```

Result:

![image](https://github.com/user-attachments/assets/96f903aa-cffe-44ce-9294-990dda6c5675)
