### PR TITLE
Extend types from ModelOptions to support new LLM parameters.

### DIFF
--- a/packages/common/src/environment.ts
+++ b/packages/common/src/environment.ts
@@ -1,4 +1,4 @@
-import { AIModel } from "@llumiverse/core";
+import { AIModel, ModelOptions } from "@llumiverse/core";
 
 
 export enum SupportedProviders {
@@ -146,14 +146,10 @@ export interface LoadBalancingEnvEntryConfig extends VirtualEnvEntry {
     weight: number;
 }
 
-export interface MediatorEnvConfig {
+export interface MediatorEnvConfig extends ModelOptions{
     entries?: VirtualEnvEntry[];
     max_concurrent_requests?: number;
-    // optional max tokens to be sued for mediation
-    max_tokens?: number;
-    // optional temperature to be used for mediation
-    temperature?: number;
-    // the model used to evaluate the repsonses. If not specified all entries will mediates the response
+    // the model used to evaluate the responses. If not specified all entries will mediates the response
     // and the best response will be picked
     mediators?: VirtualEnvEntry[];
 }

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -236,21 +236,21 @@ export interface ExecutionRunRef
 export const ExecutionRunRefSelect = "-result -parameters -result_schema -prompt";
 
 export enum ConfigModes {
-    OVERWRITE = "OVERWRITE",
-    RUN_ONLY = "RUN_ONLY",
-    INTERACTION_ONLY = "INTERACTION_ONLY"
+    RUN_AND_INTERACTION_CONFIG = "RUN_AND_INTERACTION_CONFIG",
+    RUN_CONFIG_ONLY = "RUN_CONFIG_ONLY",
+    INTERACTION_CONFIG_ONLY = "INTERACTION_CONFIG_ONLY"
 };
 
 export enum ConfigModesDescription {
-    OVERWRITE = "This run configuration is used. Undefined options are filled with interaction configuration.",
-    RUN_ONLY = "Only this run configuration is used. Undefined options remain undefined.",
-    INTERACTION_ONLY = "Only interaction configuration is used."
+    RUN_AND_INTERACTION_CONFIG = "This run configuration is used. Undefined options are filled with interaction configuration.",
+    RUN_CONFIG_ONLY = "Only this run configuration is used. Undefined options remain undefined.",
+    INTERACTION_CONFIG_ONLY = "Only interaction configuration is used."
 }
 
 export const ConfigModesOptions: Record<ConfigModes, ConfigModesDescription> = {
-    [ConfigModes.OVERWRITE]: ConfigModesDescription.OVERWRITE,
-    [ConfigModes.RUN_ONLY]: ConfigModesDescription.RUN_ONLY,
-    [ConfigModes.INTERACTION_ONLY]: ConfigModesDescription.INTERACTION_ONLY,
+    [ConfigModes.RUN_AND_INTERACTION_CONFIG]: ConfigModesDescription.RUN_AND_INTERACTION_CONFIG,
+    [ConfigModes.RUN_CONFIG_ONLY]: ConfigModesDescription.RUN_CONFIG_ONLY,
+    [ConfigModes.INTERACTION_CONFIG_ONLY]: ConfigModesDescription.INTERACTION_CONFIG_ONLY,
 }
 
 export interface InteractionExecutionConfiguration extends ModelOptions{

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -235,11 +235,30 @@ export interface ExecutionRunRef
 
 export const ExecutionRunRefSelect = "-result -parameters -result_schema -prompt";
 
+export enum ConfigModes {
+    OVERWRITE = "OVERWRITE",
+    RUN_ONLY = "RUN_ONLY",
+    INTERACTION_ONLY = "INTERACTION_ONLY"
+};
+
+export enum ConfigModesDescription {
+    OVERWRITE = "This run configuration is used. Undefined options are filled with interaction configuration.",
+    RUN_ONLY = "Only this run configuration is used. Undefined options remain undefined.",
+    INTERACTION_ONLY = "Only interaction configuration is used."
+}
+
+export const ConfigModesOptions: Record<ConfigModes, ConfigModesDescription> = {
+    [ConfigModes.OVERWRITE]: ConfigModesDescription.OVERWRITE,
+    [ConfigModes.RUN_ONLY]: ConfigModesDescription.RUN_ONLY,
+    [ConfigModes.INTERACTION_ONLY]: ConfigModesDescription.INTERACTION_ONLY,
+}
+
 export interface InteractionExecutionConfiguration extends ModelOptions{
     environment?: string;
     model?: string;
     do_validate?: boolean;
     run_data?: RunDataStorageLevel;
+    configMode?: ConfigModes;
 }
 
 export interface GenerateInteractionPayload {

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -1,4 +1,4 @@
-import type { JSONObject } from "@llumiverse/core";
+import type { JSONObject, ModelOptions } from "@llumiverse/core";
 import { JSONSchema4 } from 'json-schema';
 
 import { ExecutionTokenUsage } from '@llumiverse/core';
@@ -86,7 +86,7 @@ export interface CachePolicy {
     ttl: number;
 }
 export type InteractionVisibility = 'public' | 'private';
-export interface Interaction {
+export interface Interaction extends ModelOptions {
     readonly id: string;
     name: string;
     endpoint: string;
@@ -101,9 +101,7 @@ export interface Interaction {
     result_schema?: JSONSchema4;
     cache_policy?: CachePolicy;
     model: string;
-    temperature?: number;
     prompts: PromptSegmentDef[];
-    max_tokens?: number;
     environment: string | ExecutionEnvironmentRef;
     restriction?: RunDataStorageLevel;
     project: string | ProjectRef;
@@ -237,11 +235,9 @@ export interface ExecutionRunRef
 
 export const ExecutionRunRefSelect = "-result -parameters -result_schema -prompt";
 
-export interface InteractionExecutionConfiguration {
+export interface InteractionExecutionConfiguration extends ModelOptions{
     environment?: string;
     model?: string;
-    temperature?: number;
-    max_tokens?: number;
     do_validate?: boolean;
     run_data?: RunDataStorageLevel;
 }

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -4,6 +4,7 @@ import { activityInfo, log } from "@temporalio/activity";
 import { projectResult } from "../dsl/projections.js";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
 import { TruncateSpec, truncByMaxTokens } from "../utils/tokens.js";
+import { ModelOptions } from "@llumiverse/core";
 
 //Example:
 //@ts-ignore
@@ -52,7 +53,7 @@ const JSON: DSLActivitySpec = {
     }
 }
 
-export interface InteractionExecutionParams {
+export interface InteractionExecutionParams extends ModelOptions{
     /**
      * The environment to use. If not specified the project default environment will be used.
      * If the latter is not specified an exeption will be thrown.
@@ -64,16 +65,6 @@ export interface InteractionExecutionParams {
      * If the latter is not specified an exeption will be thrown.
      */
     model?: string;
-
-    /**
-     * Max tokens to generate for the response
-     */
-    max_tokens?: number;
-
-    /**
-     * The temperature to use for the generation
-     */
-    temperature?: number;
 
     /**
      * Force a JSON schema for the result


### PR DESCRIPTION
## Extend types from ModelOptions to support new LLM parameters.

* https://github.com/becomposable/studio/issues/616