### PR TITLE
feat/529 pass query into payload

### DIFF
--- a/packages/common/src/payload.ts
+++ b/packages/common/src/payload.ts
@@ -1,5 +1,5 @@
 import { FacetSpec } from './facets.js';
-import { InteractionSearchQuery, ObjectSearchQuery, ObjectTypeSearchQuery, PromptSearchQuery, RunSearchQuery, SimpleSearchQuery, VectorSearchQuery } from './query.js';
+import { ComplexSearchQuery, InteractionSearchQuery, ObjectSearchQuery, ObjectTypeSearchQuery, PromptSearchQuery, RunSearchQuery, SimpleSearchQuery, VectorSearchQuery } from './query.js';
 
 export interface SearchPayload {
     query?: SimpleSearchQuery;
@@ -52,8 +52,7 @@ export interface ComputeRunFacetPayload extends ComputeFacetPayload {
 export interface ExportPropertiesPayload {
     objectIds: string[];
     type: string;
-    layout?: string;
-    exportAll?: boolean;
+    query?: ComplexSearchQuery;
 }
 
 export interface ExportPropertiesResponse {


### PR DESCRIPTION
Changes the ExportPropertiesPayload to contain a query, to exporting based on the query rather than ObjectIDs.

The layout field is removed as it is query.type.
ExportAll field is no longer needed.