### PR TITLE
chore(761): remove pdfToImage

### DIFF
--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -29,7 +29,6 @@
         "@opendocsg/pdf2md": "0.2.0",
         "@pdftron/pdfnet-node": "^10.11.0",
         "mupdf": "^0.3.0",
-        "pdf2pic": "^3.1.1",
         "sharp": "^0.33.5",
         "tmp": "^0.2.3"
     },

--- a/packages/converters/src/image.test.ts
+++ b/packages/converters/src/image.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import sharp from 'sharp';
 import { expect, test } from 'vitest';
-import { createImageTransformer, pdfToImage } from './image';
+import { createImageTransformer } from './image';
 
 
 test('should resize an image to a maximum height or width', async () => {
@@ -21,30 +21,5 @@ test('should resize an image to a maximum height or width', async () => {
   expect(metadata.width).to.be.lessThanOrEqual(max_hw);
   expect(metadata.height).to.be.lessThanOrEqual(max_hw);
   expect(metadata.format).to.equal(format);
-
-});
-
-// https://github.com/becomposable/studio/issues/432 Skip tests
-// Error: Input Buffer is empty
-test.skip('should convert a pdf to image', async () => {
-  const max_hw = 1024;
-  const format: keyof sharp.FormatEnum = 'png';
-  const pdfFile = fs.readFileSync(path.join(__dirname, '../fixtures', 'test-pdf1.pdf'));
-
-  const images = await pdfToImage(pdfFile, { pages: [1], format, max_hw });
-  const image = images[0];
-  const sh = createImageTransformer(image!, { max_hw, format });
-  const buffer = await sh.toBuffer();
-  const metadata = await sharp(buffer).metadata();
-
-  //write to file for manual inspection
-  console.log(metadata);
-  //await resized.toFile('/tmp/test-pdf1.jpg');
-
-  console.log(metadata);
-  expect(metadata.width).to.be.lessThanOrEqual(max_hw);
-  expect(metadata.height).to.be.lessThanOrEqual(max_hw);
-  expect(metadata.format).to.equal(format);
-
 
 });

--- a/packages/converters/src/image.ts
+++ b/packages/converters/src/image.ts
@@ -1,4 +1,3 @@
-import { fromBuffer } from 'pdf2pic';
 import sharp from "sharp";
 
 export interface TransformOptions {
@@ -76,29 +75,4 @@ export function transformImageToBuffer(input: SharpInputType, opts: TransformOpt
 export async function transformImageToFile(input: SharpInputType, output: string, opts: TransformOptions): Promise<void> {
     const sh = createImageTransformer(input, opts);
     await sh.toFile(output);
-}
-
-export interface PdfToImageParams {
-    pages: number[];
-    format: keyof sharp.FormatEnum;
-    max_hw: number;
-}
-
-export async function pdfToImage(buffer: Buffer, { pages, format }: PdfToImageParams) {
-
-
-    const images = await fromBuffer(buffer, {
-        density: 200,
-        format: format,
-        quality: 100,
-        preserveAspectRatio: true,
-        height: 2048,
-        width: 2048,
-    }).bulk(pages,
-        { responseType: 'buffer' }
-    );
-
-    return images.map(image => image.buffer);
-
-
 }

--- a/packages/workflow/src/conversion/image.test.ts
+++ b/packages/workflow/src/conversion/image.test.ts
@@ -24,28 +24,3 @@ test('should resize an image to a maximum height or width', async () => {
   expect(metadata.format).to.equal(format);
 
 });
-
-// https://github.com/becomposable/studio/issues/432 Skip tests
-// function `pdfToImage` does not exist anymore
-//
-// test('should convert a pdf to image', async () => {
-//   const max_hw = 1024;
-//   const format: keyof sharp.FormatEnum = 'png';
-//   const pdfFile = fs.readFileSync(path.join(__dirname, '../../fixtures', 'test-pdf1.pdf'));
-
-//   const images = await pdfToImage(pdfFile, { pages: [1], format, max_hw });
-//   const image = images[0];
-//   const resized = sharp(image).pipe(imageResizer(max_hw, format));
-//   const metadata = await sharp(await resized.toBuffer()).metadata();
-
-//   //write to file for manual inspection
-//   console.log(metadata);
-//   await resized.toFile('/tmp/test-pdf1.jpg');
-
-//   console.log(metadata);
-//   expect(metadata.width).to.be.lessThanOrEqual(max_hw);
-//   expect(metadata.height).to.be.lessThanOrEqual(max_hw);
-//   expect(metadata.format).to.equal(format);
-
-
-// });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,6 @@ importers:
       mupdf:
         specifier: ^0.3.0
         version: 0.3.0
-      pdf2pic:
-        specifier: ^3.1.1
-        version: 3.1.3
       sharp:
         specifier: ^0.33.5
         version: 0.33.5


### PR DESCRIPTION
This function had been replaced by `pdfToImages`. Let's remove it.