### PR TITLE
Fix(86): Allow ModelOptions in InteractionUpdatePayload to be null

### DIFF
--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -131,9 +131,20 @@ export interface InteractionUpdatePayload
         Omit<
             Interaction,
             "result_schema" | "id" | "created_at" | "updated_at" | "created_by" | "updated_by" | "project"
+            | "temperature" | "max_tokens" | "stop_sequence" | "top_k" | "top_p" | "presence_penalty" | "frequency_penalty" | "top_logprobs"
         >
     > {
     result_schema?: JSONSchema4 | null;
+
+    // Change ModelOptions properties to include null as a possible type
+    temperature?: number | null;
+    max_tokens?: number | null;
+    stop_sequence?: string[] | null;
+    top_k?: number | null;
+    top_p?: number | null;
+    top_logprobs?: number | null;
+    presence_penalty?: number | null;
+    frequency_penalty?: number | null;
 }
 
 export interface InteractionPublishPayload {

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -137,6 +137,7 @@ export interface InteractionUpdatePayload
     result_schema?: JSONSchema4 | null;
 
     // Change ModelOptions properties to include null as a possible type
+    // Null values indicate that the property should be cleared.
     temperature?: number | null;
     max_tokens?: number | null;
     stop_sequence?: string[] | null;


### PR DESCRIPTION
* https://github.com/becomposable/studio/issues/86

Allows ModelOptions properties in InteractionUpdatePayload inherited from Interaction to be null.
For use as a special value indicating that the property should be cleared.

Related studio PR:
* https://github.com/becomposable/studio/pull/744